### PR TITLE
로그인/댓글 응답 개선 및 CORS 설정

### DIFF
--- a/src/main/java/kr/ac/cbnu/tux/config/CorsConfig.java
+++ b/src/main/java/kr/ac/cbnu/tux/config/CorsConfig.java
@@ -1,0 +1,30 @@
+package kr.ac.cbnu.tux.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Component
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of(
+                "http://localhost:*",
+                "https://tux.cbnu.ac.kr",
+                "https://tux.studio1122.net"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/kr/ac/cbnu/tux/config/SecurityConfig.java
+++ b/src/main/java/kr/ac/cbnu/tux/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,7 +31,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
         return http
-                .cors(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/kr/ac/cbnu/tux/controller/CommunityController.java
+++ b/src/main/java/kr/ac/cbnu/tux/controller/CommunityController.java
@@ -4,6 +4,7 @@ import kr.ac.cbnu.tux.domain.Attachment;
 import kr.ac.cbnu.tux.domain.CmComment;
 import kr.ac.cbnu.tux.domain.Community;
 import kr.ac.cbnu.tux.domain.User;
+import kr.ac.cbnu.tux.dto.CmCommentDTO;
 import kr.ac.cbnu.tux.dto.CommunityDTO;
 import kr.ac.cbnu.tux.dto.CommunityListDTO;
 import kr.ac.cbnu.tux.enums.CommunityPostType;
@@ -164,10 +165,12 @@ public class CommunityController {
     /* 댓글 */
     @PostMapping("/api/community/{id}/comment")
     @ResponseStatus(code = HttpStatus.ACCEPTED)
-    public void addComment(@PathVariable("id") Long id, @RequestBody CmComment comment,
-                           @AuthenticationPrincipal User user) {
+    @ResponseBody
+    public CmCommentDTO addComment(@PathVariable("id") Long id, @RequestBody CmComment comment,
+                                   @AuthenticationPrincipal User user) {
 
-        communityService.addComment(id, comment, user);
+        CmComment savedComment = communityService.addComment(id, comment, user);
+        return CmCommentDTO.build(savedComment);
     }
 
     @DeleteMapping("/api/community/{id}/comment/{commentId}")

--- a/src/main/java/kr/ac/cbnu/tux/controller/UserController.java
+++ b/src/main/java/kr/ac/cbnu/tux/controller/UserController.java
@@ -27,12 +27,14 @@ public class UserController {
 
     @PostMapping("/api/auth")
     @ResponseStatus(code = HttpStatus.OK)
-    public void login(final HttpServletRequest request, final HttpServletResponse response,
+    @ResponseBody
+    public UserDTO login(final HttpServletRequest request, final HttpServletResponse response,
                       @RequestBody LoginDTO loginDTO) {
         try {
-            String token = userService.tryLogin(loginDTO);
-            Cookie tokenCookie = createTokenCookie(token, 168 * 60 * 60);
+            UserDTO userAndToken = userService.tryLogin(loginDTO);
+            Cookie tokenCookie = createTokenCookie(userAndToken.getToken().getToken(), 168 * 60 * 60);
             response.addCookie(tokenCookie);
+            return userAndToken;
 
         } catch (Exception e) {
             Cookie emptyCookie = createTokenCookie(null, 0);

--- a/src/main/java/kr/ac/cbnu/tux/controller/UserController.java
+++ b/src/main/java/kr/ac/cbnu/tux/controller/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
 
     @GetMapping("/api/auth")
     @ResponseBody
-    public UserDTO getCurrent(@AuthenticationPrincipal User user) {
+    public UserDTO getCurrentUser(@AuthenticationPrincipal User user) {
         return UserDTO.build(user);
     }
 
@@ -76,12 +76,16 @@ public class UserController {
 
     @DeleteMapping("/api/user/{id}")
     @ResponseStatus(code = HttpStatus.ACCEPTED)
-    public void delete(@PathVariable("id") Long id, @AuthenticationPrincipal User currentUser) throws Exception {
+    public void delete(@PathVariable("id") Long id,
+                       @AuthenticationPrincipal User currentUser, final HttpServletResponse response) throws Exception {
         if (!Objects.deepEquals(currentUser.getId(), id)) {
             throw new Exception("user not matched");
         }
 
         userService.userDelete(id);
+
+        Cookie tokenCookie = createTokenCookie(null, 0);
+        response.addCookie(tokenCookie);
     }
 
     @GetMapping("/api/user/{id}")

--- a/src/main/java/kr/ac/cbnu/tux/dto/LoginDTO.java
+++ b/src/main/java/kr/ac/cbnu/tux/dto/LoginDTO.java
@@ -1,8 +1,11 @@
 package kr.ac.cbnu.tux.dto;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 public class LoginDTO {
 
     private String username;

--- a/src/main/java/kr/ac/cbnu/tux/dto/TokenDTO.java
+++ b/src/main/java/kr/ac/cbnu/tux/dto/TokenDTO.java
@@ -1,0 +1,25 @@
+package kr.ac.cbnu.tux.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TokenDTO {
+
+    private String token;
+    private Long expiresIn;
+
+    public static TokenDTO build(String token, long expiresIn) {
+        return TokenDTO.builder()
+                .token(token)
+                .expiresIn(expiresIn)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/cbnu/tux/dto/UserDTO.java
+++ b/src/main/java/kr/ac/cbnu/tux/dto/UserDTO.java
@@ -28,7 +28,13 @@ public class UserDTO {
     private OffsetDateTime createdDate;
     private OffsetDateTime deletedDate;
 
+    private TokenDTO token;
+
     public static UserDTO build(User user) {
+        return build(user, null);
+    }
+
+    public static UserDTO build(User user, TokenDTO token) {
         return UserDTO.builder()
                 .id(user.getId())
                 .username(user.getUsername())
@@ -42,6 +48,7 @@ public class UserDTO {
                 .isBanned(user.isBanned())
                 .createdDate(user.getCreatedDate())
                 .deletedDate(user.getDeletedDate())
+                .token(token)
                 .build();
     }
 

--- a/src/main/java/kr/ac/cbnu/tux/security/JwtTokenProvider.java
+++ b/src/main/java/kr/ac/cbnu/tux/security/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import io.micrometer.common.util.StringUtils;
 import kr.ac.cbnu.tux.domain.User;
+import kr.ac.cbnu.tux.dto.TokenDTO;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -17,7 +18,7 @@ public class JwtTokenProvider {
     private static final Key JWT_SECRET_KEY = Keys.hmacShaKeyFor(JWT_SECRET.getBytes());
 
     // Token Expiration Time
-    private static final int JWT_EXPIRATION_MS = 8 * 24 * 60 * 60 * 1000;
+    private static final int JWT_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000;
 
     private final static JwtParser jwtParser;
 
@@ -27,16 +28,22 @@ public class JwtTokenProvider {
                 .build();
     }
 
-    public static String generateToken(Authentication authentication) {
+    public static TokenDTO generateToken(Authentication authentication) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + JWT_EXPIRATION_MS);
 
-        return Jwts.builder()
-                .setSubject(((UserDetails)authentication.getPrincipal()).getUsername())
-                .setIssuedAt(now)
-                .setExpiration(expiryDate)
-                .signWith(JWT_SECRET_KEY, SignatureAlgorithm.HS512)
-                .compact();
+        return TokenDTO.build(
+                Jwts.builder()
+                        // username을 "sub"라는 claim으로 토큰에 추가
+                        .setSubject(((UserDetails)authentication.getPrincipal()).getUsername())
+                        // 회원 권한을 "role"이라는 claim으로 토큰에 추가
+                        .claim("role", authentication.getAuthorities())
+                        .setIssuedAt(now)
+                        .setExpiration(expiryDate)
+                        .signWith(JWT_SECRET_KEY, SignatureAlgorithm.HS512)
+                        .compact(),
+                expiryDate.getTime()
+        );
     }
 
     public static String getUsernameFromJwt(String token) {

--- a/src/main/java/kr/ac/cbnu/tux/service/CommunityService.java
+++ b/src/main/java/kr/ac/cbnu/tux/service/CommunityService.java
@@ -152,14 +152,14 @@ public class CommunityService {
     /* 댓글 관련 코드 */
 
     @Transactional
-    public void addComment(Long id, CmComment comment, User user) {
+    public CmComment addComment(Long id, CmComment comment, User user) {
         Community post = communityRepository.findById(id).orElseThrow();
 
         comment.setCreatedDate(OffsetDateTime.now());
         comment.setIsDeleted(false);
         comment.setPost(post);
         comment.setUser(user);
-        cmCommentRepository.save(comment);
+        return cmCommentRepository.save(comment);
     }
 
     @Transactional

--- a/src/main/java/kr/ac/cbnu/tux/service/UserService.java
+++ b/src/main/java/kr/ac/cbnu/tux/service/UserService.java
@@ -3,12 +3,12 @@ package kr.ac.cbnu.tux.service;
 import jakarta.transaction.Transactional;
 import kr.ac.cbnu.tux.domain.User;
 import kr.ac.cbnu.tux.dto.LoginDTO;
+import kr.ac.cbnu.tux.dto.UserDTO;
 import kr.ac.cbnu.tux.enums.UserRole;
 import kr.ac.cbnu.tux.repository.UserRepository;
 import kr.ac.cbnu.tux.security.JwtTokenProvider;
 import kr.ac.cbnu.tux.security.UserAuthentication;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -108,7 +108,7 @@ public class UserService implements UserDetailsService {
         user.setPassword(passwordEncoder.encode(password));
     }
 
-    public String tryLogin(LoginDTO loginDTO) throws UsernameNotFoundException {
+    public UserDTO tryLogin(LoginDTO loginDTO) throws UsernameNotFoundException {
         User user = userRepository.findUserByUsername(loginDTO.getUsername())
                 .orElseThrow(() -> new UsernameNotFoundException("user not present"));
 
@@ -119,7 +119,10 @@ public class UserService implements UserDetailsService {
             Authentication authentication = new UserAuthentication(
                     user, loginDTO.getPassword(), user.getAuthorities()
             );
-            return JwtTokenProvider.generateToken(authentication);
+            return UserDTO.build(
+                    user,
+                    JwtTokenProvider.generateToken(authentication)
+            );
         } else {
             throw new IllegalArgumentException("password not matched");
         }
@@ -127,6 +130,10 @@ public class UserService implements UserDetailsService {
 
     public Optional<User> read(Long id) {
         return userRepository.findById(id);
+    }
+
+    public User readByUsername(String username) {
+        return userRepository.findUserByUsername(username).orElseThrow();
     }
 
     @Override


### PR DESCRIPTION
## 주요 변경 사항

### 로그인 응답 개선
- 로그인 성공 시 클라이언트에 **JWT 토큰 + 만료 일시**를 함께 전달하도록 DTO 수정
- 프론트에서 토큰 유효성 체크를 할 필요 없도록 개선

### CORS 설정 추가
- 개발 및 배포 환경에서 프론트엔드 요청을 허용하도록 CORS 정책 구성
  - `http://localhost:*`, `https://tux.cbnu.ac.kr`, `https://tux.studio1122.net` 등 허용
  - 모든 메서드(`GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`)와 헤더 허용

### 댓글 등록 시 응답 개선
- 댓글 작성 API에서 단순 성공 여부만 반환하던 방식 → 작성된 **댓글 DTO**를 응답으로 반환하도록 변경
- 프론트엔드에서 새로 작성된 댓글을 즉시 렌더링할 수 있도록 대응