### PR TITLE
댓글 추가시 객체 응답 반환

### DIFF
--- a/src/main/java/kr/ac/cbnu/tux/controller/ReferenceRoomController.java
+++ b/src/main/java/kr/ac/cbnu/tux/controller/ReferenceRoomController.java
@@ -6,6 +6,7 @@ import kr.ac.cbnu.tux.domain.RfComment;
 import kr.ac.cbnu.tux.domain.User;
 import kr.ac.cbnu.tux.dto.ReferenceRoomDTO;
 import kr.ac.cbnu.tux.dto.ReferenceRoomListDTO;
+import kr.ac.cbnu.tux.dto.RfCommentDTO;
 import kr.ac.cbnu.tux.enums.ReferenceRoomPostType;
 import kr.ac.cbnu.tux.enums.UserRole;
 import kr.ac.cbnu.tux.service.AttachmentService;
@@ -177,9 +178,11 @@ public class ReferenceRoomController {
     /* 댓글 */
     @PostMapping("/api/referenceroom/{id}/comment")
     @ResponseStatus(code = HttpStatus.ACCEPTED)
-    public void addComment(@PathVariable("id") Long id, @RequestBody RfComment comment,
+    @ResponseBody
+    public RfCommentDTO addComment(@PathVariable("id") Long id, @RequestBody RfComment comment,
                            @AuthenticationPrincipal User user) {
-        referenceRoomService.addComment(id, comment, user);
+        RfComment savedComment = referenceRoomService.addComment(id, comment, user);
+        return RfCommentDTO.build(savedComment);
     }
 
     @DeleteMapping("/api/referenceroom/{id}/comment/{commentId}")

--- a/src/main/java/kr/ac/cbnu/tux/service/ReferenceRoomService.java
+++ b/src/main/java/kr/ac/cbnu/tux/service/ReferenceRoomService.java
@@ -163,13 +163,13 @@ public class ReferenceRoomService {
     /* 댓글 관련 코드 */
 
     @Transactional
-    public void addComment(Long id, RfComment comment, User user) {
+    public RfComment addComment(Long id, RfComment comment, User user) {
         ReferenceRoom data = referenceRoomRepository.findById(id).orElseThrow();
         comment.setCreatedDate(OffsetDateTime.now());
         comment.setIsDeleted(false);
         comment.setData(data);
         comment.setUser(user);
-        rfCommentRepository.save(comment);
+        return rfCommentRepository.save(comment);
     }
 
     @Transactional


### PR DESCRIPTION
## 주요 변경 사항

### 자료실 댓글 등록 시 응답 개선
- 댓글 작성 API에서 단순 성공 여부만 반환하던 방식 → 작성된 **댓글 DTO**를 응답으로 반환하도록 변경
- 프론트엔드에서 새로 작성된 댓글을 즉시 렌더링할 수 있도록 대응